### PR TITLE
feat(web): 기본 레이아웃 및 네비게이션 추가

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+// 기본 레이아웃
+</script>
+
+<nav>
+  <a href="/">홈</a>
+  <a href="/games">게임 허브</a>
+</nav>
+
+<slot />


### PR DESCRIPTION
## 요약
- 홈과 게임 허브를 오갈 수 있는 기본 레이아웃과 네비게이션 추가

## 테스트
- `npm test` (실패: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_68be7b74208c83308f42029709616ce6